### PR TITLE
MASSEMBLY-668: Adopted plugin for changes in Plexus Archiver related to support of ownership information in DirectoryArchiver

### DIFF
--- a/src/main/java/org/apache/maven/plugins/assembly/archive/archiver/AssemblyProxyArchiver.java
+++ b/src/main/java/org/apache/maven/plugins/assembly/archive/archiver/AssemblyProxyArchiver.java
@@ -1221,6 +1221,40 @@ public class AssemblyProxyArchiver
         delegate.setIgnorePermissions( ignorePermissions );
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isIgnoreOwner()
+    {
+        inPublicApi.set( Boolean.TRUE );
+        try
+        {
+            return delegate.isIgnoreOwner();
+        }
+        finally
+        {
+            inPublicApi.set( null );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setIgnoreOwner( final boolean ignoreOwner )
+    {
+        inPublicApi.set( Boolean.TRUE );
+        try
+        {
+            delegate.setIgnoreOwner( ignoreOwner );
+        }
+        finally
+        {
+            inPublicApi.set( null );
+        }
+    }
+
     private static final class DefaultFileInfo
         implements FileInfo
     {


### PR DESCRIPTION
MASSEMBLY-668: Adopted plugin for changes in Plexus Archiver related to support of ownership information in DirectoryArchiver - refer to [pull request #2](https://github.com/mabrarov/plexus-archiver/pull/2) in [mabrarov/plexus-archiver](https://github.com/mabrarov/plexus-archiver)